### PR TITLE
fix encoding of binary list with trailing zeroes

### DIFF
--- a/lib/ex_rlp/encode.ex
+++ b/lib/ex_rlp/encode.ex
@@ -81,7 +81,7 @@ defimpl ExRLP.Encode, for: List do
   end
 
   defp prefix_list(encoded_concat) do
-    be_size = Utils.big_endian_size(encoded_concat)
+    be_size = Utils.big_endian_size(encoded_concat, true)
     byte_size = byte_size(be_size)
 
     <<247 + byte_size>> <> be_size <> encoded_concat

--- a/lib/ex_rlp/utils.ex
+++ b/lib/ex_rlp/utils.ex
@@ -10,9 +10,19 @@ defmodule ExRLP.Utils do
     binary |> Base.encode16(case: :lower)
   end
 
-  @spec big_endian_size(binary()) :: bitstring()
-  def big_endian_size(binary) do
+  @spec big_endian_size(binary(), boolean()) :: bitstring()
+  def big_endian_size(binary, trim_trailing_zeroes \\ false)
+
+  def big_endian_size(binary, false) do
     binary
+    |> byte_size
+    |> :binary.encode_unsigned()
+  end
+
+  def big_endian_size(binary, true) do
+    binary
+    |> :binary.decode_unsigned(:little)
+    |> :binary.encode_unsigned(:big)
     |> byte_size
     |> :binary.encode_unsigned()
   end

--- a/test/ex_rlp/decode_test.exs
+++ b/test/ex_rlp/decode_test.exs
@@ -14,11 +14,11 @@ defmodule ExRLP.DecodeTest do
 
         result =
           input
-          |> Decode.decode(encoding: :hex)
+          |> normalize_data()
+          |> Decode.decode()
           |> normalize_decoded_data(expected_result)
 
-        assert result == expected_result,
-               "Test for #{test_name} failed, expected #{result} to equal to #{expected_result}"
+        assert result == expected_result, "#{test_name} failed"
       end)
     end
 

--- a/test/ex_rlp/encode_test.exs
+++ b/test/ex_rlp/encode_test.exs
@@ -15,7 +15,7 @@ defmodule ExRLP.EncodeTest do
           |> normalize_data()
           |> Encode.encode(encoding: :hex)
 
-        assert result == expected_result,
+        assert "0x#{result}" == expected_result,
                "Test for #{test_name} failed, expected #{result} to equal to #{expected_result}"
       end)
     end

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -14,12 +14,24 @@ defmodule ExRLP.TestUtils do
     num
   end
 
+  def normalize_data("0x" <> number) do
+    Base.decode16!(number, case: :lower)
+  end
+
+  def normalize_data(data) when is_list(data) do
+    Enum.map(data, &normalize_data/1)
+  end
+
   def normalize_data(input), do: input
 
   def normalize_decoded_data(input, output, acc \\ [])
 
   def normalize_decoded_data(input, output, _) when is_number(output) do
-    input |> :binary.decode_unsigned()
+    :binary.decode_unsigned(input)
+  end
+
+  def normalize_decoded_data("0x" <> input, _output, _) do
+    Base.decode16!(input, case: :lower)
   end
 
   def normalize_decoded_data([], [], acc), do: acc

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -34,12 +34,12 @@ defmodule ExRLP.TestUtils do
     Base.decode16!(input, case: :lower)
   end
 
-  def normalize_decoded_data([], [], acc), do: acc
+  def normalize_decoded_data([], [], acc), do: Enum.reverse(acc)
 
   def normalize_decoded_data([in_head | in_tail], [out_head | out_tail], acc) do
     normalized_item = normalize_decoded_data(in_head, out_head)
 
-    normalize_decoded_data(in_tail, out_tail, acc ++ [normalized_item])
+    normalize_decoded_data(in_tail, out_tail, [normalized_item | acc])
   end
 
   def normalize_decoded_data(input, _output, _acc), do: input


### PR DESCRIPTION
Changes:
- Fix encoding of a binary list with trailing zeroes
- A new test case was added for RLP encoding: https://github.com/ethereum/tests/pull/554
- Hex values format was changed in tests: https://github.com/ethereum/tests/pull/557