### PR TITLE
add test: check if decoding is one to one by generating collisions

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,8 @@ defmodule ExRLP.Mixfile do
       {:credo, "~> 0.10.2", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.19", only: :dev, runtime: false},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
-      {:poison, "~> 4.0.1", only: [:dev, :test], runtime: false}
+      {:poison, "~> 4.0.1", only: [:dev, :test], runtime: false},
+      {:propcheck, "~> 1.1", only: [:test, :dev]}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -9,4 +9,6 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},
   "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm"},
+  "propcheck": {:hex, :propcheck, "1.2.0", "e2b84f2f1a4c46b6b2aa22a0f6ddf97696f99d4a5c8f71d45f6519741e727eca", [:mix], [{:proper, "~> 1.3", [hex: :proper, repo: "hexpm", optional: false]}], "hexpm"},
+  "proper": {:hex, :proper, "1.3.0", "c1acd51c51da17a2fe91d7a6fc6a0c25a6a9849d8dc77093533109d1218d8457", [:make, :mix, :rebar3], [], "hexpm"},
 }

--- a/test/ex_rlp/property_test.exs
+++ b/test/ex_rlp/property_test.exs
@@ -1,0 +1,23 @@
+defmodule ExRLP.PropTest do
+  @moduledoc false
+
+  use PropCheck
+  use ExUnit.Case
+
+  def safe_decode(t) do
+    try do
+      ExRLP.decode(t)
+    rescue
+      _ -> false
+    end
+  end
+
+  property "decoding is one to one", [1000, :verbose, max_size: 100, constraint_tries: 100_000] do
+    gen = such_that(bin <- binary(), when: false != safe_decode(bin))
+
+    forall l <- list(gen) do
+      mapsto = for item <- :lists.usort(l), do: ExRLP.decode(item)
+      :lists.sort(mapsto) == :lists.usort(mapsto)
+    end
+  end
+end

--- a/test/ex_rlp/property_test.exs
+++ b/test/ex_rlp/property_test.exs
@@ -20,4 +20,25 @@ defmodule ExRLP.PropTest do
       :lists.sort(mapsto) == :lists.usort(mapsto)
     end
   end
+
+  property "for any string encoding is one to one", [1000, :verbose, max_size: 100] do
+    forall l <- binary() do
+      encoded = ExRLP.encode(l)
+      decoded = ExRLP.decode(encoded)
+      l == decoded
+    end
+  end
+
+  property "for lists encoding is one to one", [1000, :verbose, max_size: 100] do
+    forall l <-
+             union([
+               list(binary()),
+               binary(),
+               union([list(binary()), binary(), union([list(binary()), binary()])])
+             ]) do
+      encoded = ExRLP.encode(l)
+      decoded = ExRLP.decode(encoded)
+      l == decoded
+    end
+  end
 end

--- a/test/ex_rlp/property_test.exs
+++ b/test/ex_rlp/property_test.exs
@@ -4,6 +4,8 @@ defmodule ExRLP.PropTest do
   use PropCheck
   use ExUnit.Case
 
+  @moduletag timeout: 120_000
+
   def safe_decode(binary) do
     try do
       ExRLP.decode(binary)
@@ -46,8 +48,8 @@ defmodule ExRLP.PropTest do
     forall l <-
              union([
                list(binary()),
-               binary(),
-               union([list(binary()), binary(), union([list(binary()), binary()])])
+               list(union([binary(), list(binary())])),
+               list(union([binary(), list(binary()), list(union([binary(), list(binary())]))]))
              ]) do
       encoded = ExRLP.encode(l)
       decoded = ExRLP.decode(encoded)

--- a/test/ex_rlp/property_test.exs
+++ b/test/ex_rlp/property_test.exs
@@ -4,20 +4,30 @@ defmodule ExRLP.PropTest do
   use PropCheck
   use ExUnit.Case
 
-  def safe_decode(t) do
+  def safe_decode(binary) do
     try do
-      ExRLP.decode(t)
+      ExRLP.decode(binary)
     rescue
-      _ -> false
+      _ -> :decoder_crashed
     end
   end
 
+  # Looks for cases where decoding is not one-to-one. Note: no claims about the encoder are checked here!
+  # If we will find two distinct binaries that decode to the same elixir value, we've found our counterexample.
+  # Lists and sorting are used as a performance optimization.
+  # This allows us to do n^2 effective checks in search space while making just n runs of generator,
+  # 2n runs of the decoder and n*log(n) value comparisons.
   property "decoding is one to one", [1000, :verbose, max_size: 100, constraint_tries: 100_000] do
-    gen = such_that(bin <- binary(), when: false != safe_decode(bin))
+    # This generator will generate random binaries until one will decode or constraint_tries.
+    decodable_binary_generator =
+      such_that(bin <- binary(), when: :decoder_crashed != safe_decode(bin))
 
-    forall l <- list(gen) do
-      mapsto = for item <- :lists.usort(l), do: ExRLP.decode(item)
-      :lists.sort(mapsto) == :lists.usort(mapsto)
+    forall list_of_decodable_binaries <- list(decodable_binary_generator) do
+      # Make sure there are no duplicates in encoded values.
+      list_of_decodable_binaries = :lists.usort(list_of_decodable_binaries)
+      decoded_items = for item <- list_of_decodable_binaries, do: ExRLP.decode(item)
+      # Assert that list of decoded structures contain no duplicates.
+      :lists.sort(decoded_items) == :lists.usort(decoded_items)
     end
   end
 
@@ -29,6 +39,9 @@ defmodule ExRLP.PropTest do
     end
   end
 
+  # This test searches in at most 3 layers of nesting for lists because of lack of
+  # support for recursive types in propcheck.
+  # For details see: https://github.com/alfert/propcheck/issues/5 and related issues / PRs.
   property "for lists encoding is one to one", [1000, :verbose, max_size: 100] do
     forall l <-
              union([


### PR DESCRIPTION
Two encodings that produce identical term: `<<47>>` and `<<129,47>>`. This is a violation of "choose optimal length encoding" rule in from protocol description here: https://github.com/ethereum/wiki/wiki/RLP

```
Note that the decode_length function rejects invalid encodings that have "non-optimal"
lengths, namely (1) singleton strings whose only byte is below 128 that are encoded
with a short (i.e. one-byte) length of 1 instead of as the strings themselves and (2) 
strings and lists with long (i.e. multi-byte) lengths with leading zeros (which must be
absent) or below 56 (which should be encoded using short lengths).
```

This PR contains test detecting the error only, no fix.